### PR TITLE
Add configURL to identity providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The second stage consists of the RP performing a FedCM call. It's not much diffe
 navigator.credentials.get({
   identity: {
     providers: [{
+      configURL: 'any',
       type: "indieauth",
     }]
   }


### PR DESCRIPTION
add identity.providers[0].configURL = 'any' to the documented navigator.credentails.get call to match what works in chrome for me